### PR TITLE
XML Parsing fix if a rails resource contains underscores rather than CamelCase

### DIFF
--- a/ActiveResource.php
+++ b/ActiveResource.php
@@ -531,8 +531,8 @@ class ActiveResource {
 
 		// parse XML response
 		$xml = new SimpleXMLElement ($res);
-
-		if ($xml->getName () == $this->element_name_plural) {
+		// normalize xml element name in case rails ressource contains an underscore
+		if (str_replace("-","_", $xml->getName ()) == $this->element_name_plural) {
 			// multiple
 			$res = array ();
 			$cls = get_class ($this);


### PR DESCRIPTION
```
A possible underscore in a rails resource would be replaced by a
hyphen in a xml response, eg. 'ex_user' becomes '<ex-user>'.
This change normalizes the response to correctly parse and return xml objects.
```
